### PR TITLE
Null Robust Redis Transport

### DIFF
--- a/coastal/src/main/java/za/ac/sun/cs/coastal/strategy/pathbased/PathBasedInteractiveFactory.java
+++ b/coastal/src/main/java/za/ac/sun/cs/coastal/strategy/pathbased/PathBasedInteractiveFactory.java
@@ -184,7 +184,7 @@ public abstract class PathBasedInteractiveFactory implements StrategyFactory {
 //            String[] parts = input.split(" ");
             char[] parts = input.toCharArray();
             System.out.println(input);
-            for (int i = 0; i < parts.length; i++) {
+            for (int i = 1; i < parts.length; i++) { // drop the leading underscore
                 log.info("Adding to model " + (int) parts[i]);
                 values.put("A$" + i, new Long((int) parts[i]));
             }

--- a/coastal/src/main/java/za/ac/sun/cs/coastal/strategy/pathbased/PathBasedInteractiveFactory.java
+++ b/coastal/src/main/java/za/ac/sun/cs/coastal/strategy/pathbased/PathBasedInteractiveFactory.java
@@ -184,7 +184,7 @@ public abstract class PathBasedInteractiveFactory implements StrategyFactory {
 //            String[] parts = input.split(" ");
             char[] parts = input.toCharArray();
             System.out.println(input);
-            for (int i = 1; i < parts.length; i++) { // drop the leading underscore
+            for (int i = 0; i < parts.length; i++) {
                 log.info("Adding to model " + (int) parts[i]);
                 values.put("A$" + i, new Long((int) parts[i]));
             }

--- a/coastal/src/main/java/za/ac/sun/cs/coastal/strategy/pathbased/PathBasedInteractiveFactory.java
+++ b/coastal/src/main/java/za/ac/sun/cs/coastal/strategy/pathbased/PathBasedInteractiveFactory.java
@@ -215,6 +215,9 @@ public abstract class PathBasedInteractiveFactory implements StrategyFactory {
                     log.info(request);
                     String newString = "";
                     for (String part : request) {
+                        if (part.equals("epsilon")) {
+                            break;
+                        }
                         int nextChar = (Integer.parseInt(part));
                         log.info(nextChar);
                         if (nextChar < 0) {

--- a/coastal/src/main/java/za/ac/sun/cs/coastal/strategy/pathbased/PathBasedInteractiveFactory.java
+++ b/coastal/src/main/java/za/ac/sun/cs/coastal/strategy/pathbased/PathBasedInteractiveFactory.java
@@ -184,7 +184,7 @@ public abstract class PathBasedInteractiveFactory implements StrategyFactory {
 //            String[] parts = input.split(" ");
             char[] parts = input.toCharArray();
             System.out.println(input);
-            for (int i = 1; i < parts.length; i++) { // drop the leading underscore
+            for (int i = 0; i < parts.length; i++) {
                 log.info("Adding to model " + (int) parts[i]);
                 values.put("A$" + i, new Long((int) parts[i]));
             }
@@ -207,15 +207,29 @@ public abstract class PathBasedInteractiveFactory implements StrategyFactory {
 
 
                     // Wait for a refinement request to be issued
-                    String request;
-                    while ((request = jedis.get("refine")) == null) {
+                    while (!(jedis.exists("refine"))) {
                         continue;
                     }
+
+                    List<String> request = jedis.lrange("refine", 0, -1);
+                    log.info(request);
+                    String newString = "";
+                    for (String part : request) {
+                        int nextChar = (Integer.parseInt(part));
+                        log.info(nextChar);
+                        if (nextChar < 0) {
+                            break;
+                        } else {
+                            newString += (char) nextChar;
+                        }
+                    }
+
+                    log.info(newString);
 
                     // Remove refinement request from redis
                     jedis.del("refine");
 
-                    Model mdl = createModelFromInput(request);
+                    Model mdl = createModelFromInput(newString);
 
                     int m = coastal.addDiverModels(Collections.singletonList(mdl));
                     int d = -1;

--- a/src/symlearn/coastal.clj
+++ b/src/symlearn/coastal.clj
@@ -32,10 +32,11 @@
   "Returns [boolean list] of accepted? and path conditions"
   [string]
   ;; enqueue the string for solving
-  (let [exploded-string (map int (.toCharArray string))] ;; avoid "first byte is null" encoding issues
+  (let [exploded-string (map int (.toCharArray string))
+        strlen (count string)] ;; avoid "first byte is null" encoding issues
     (wcar* (car/del :refine)
            (car/del :refined)
-           (apply (partial car/rpush :refine) exploded-string)))
+           (apply (partial car/rpush :refine) (if (= 0 strlen) ["epsilon"] exploded-string))))
 
   ;; wait for a solved response
   (while (not= 1 (wcar* (car/exists :refined))))

--- a/src/symlearn/coastal.clj
+++ b/src/symlearn/coastal.clj
@@ -31,7 +31,7 @@
   "Returns [boolean list] of accepted? and path conditions"
   [string]
   (wcar* (car/del :refined)
-         (car/set :refine (str "_" string)))
+         (car/set :refine string))
 
   (while (not= 1 (wcar* (car/exists :refined))))
   (let [refined-path (tufte/p ::refine-path (wcar* (car/get :refined)))

--- a/src/symlearn/coastal.clj
+++ b/src/symlearn/coastal.clj
@@ -32,7 +32,7 @@
   "Returns [boolean list] of accepted? and path conditions"
   [string]
   ;; enqueue the string for solving
-  (let [exploded-string (map int (.toCharArray string))
+  (let [exploded-string (map int (.toCharArray ^String string))
         strlen (count string)] ;; avoid "first byte is null" encoding issues
     (wcar* (car/del :refine)
            (car/del :refined)
@@ -144,7 +144,10 @@
   (let [parser-src (intervals/sfa->java (intervals/regex->sfa regex) "examples.tacas2017" "Regex")]
     (spit "coastal/src/main/java/examples/tacas2017/Regex.java" parser-src)
     (compile-parsers!)
-    (start!)))
+    (start!)
+    ;; flush the result from the default run
+    (refine-string "")
+    ::ok))
 
 (defn running?
   []

--- a/src/symlearn/coastal.clj
+++ b/src/symlearn/coastal.clj
@@ -139,7 +139,7 @@
 (defn suffixes
   "Return the suffixes of the path condition pc"
   [constraint-sets]
-  (for [n (range (count constraint-sets))]
+  (for [n (range 1 (count constraint-sets))]
     (->> constraint-sets
          (drop n)
          vec)))
@@ -147,12 +147,15 @@
 (defn prefixes
   "Return every prefix of `path`, including `path`."
   [constraint-sets]
-  (for [n (range (count constraint-sets))]
+  (for [n (range 1 (count constraint-sets))]
     (->> constraint-sets
          reverse
          (drop n)
          reverse
          vec)))
+
+(assert (= [[#{:a} #{:b}] [#{:a}]] (prefixes [#{:a} #{:b} #{:c}])))
+(assert (= [[#{:b} #{:c}] [#{:c}]] (suffixes [#{:a} #{:b} #{:c}])))
 
 ;; create and fill the table
 
@@ -223,28 +226,36 @@
           (update-in [:S] #(assoc % promotee row))))
     table))
 
+(query "ab")
+(prefixes (:constraints (query "ab")))
+
+(-> (make-table)
+    (fill)
+    (add-path-condition (query "a"))
+    (add-path-condition (query "0-0-0"))
+    (add-evidence "b")
+    (fill)
+    (close)
+    (close)
+    ;; (fill)
+    ;; (closed?)
+    ;; (open-entries)
+    ;;  (close)
+    ;; (close)
+    ;; (keys)
+    (clojure.pprint/pprint)
+    ;; (fill)
+    ;; (fill)
+    ;; (:R)
+    ;; section->map
+    ;; (closed?)
+    ;; (open-entries)
+    #_(as-> $ (map (comp length :path) $)))
+
 
 (comment
 
 
-  (-> (make-table)
-      (fill)
-      (add-path-condition (query "0-0"))
-      (add-path-condition (query "0-0-0"))
-      ;; (fill)
-      ;; (closed?)
-      (open-entries)
-      ;;  (close)
-      ;; (close)
-      ;; (keys)
-      (clojure.pprint/pprint)
-      ;; (fill)
-      ;; (fill)
-      ;; (:R)
-      ;; section->map
-      ;; (closed?)
-      ;; (open-entries)
-      #_(as-> $ (map (comp length :path) $)))
 
   ;; install the castle move parser
   (install-parser! "0-0(-0)?\\+?")

--- a/src/symlearn/z3.clj
+++ b/src/symlearn/z3.clj
@@ -13,7 +13,7 @@
       (format "(assert (not (%s a %s)))\n" op bound)
       (format "(assert (%s a %s))\n" op bound))))
 
-(defn- solve
+(defn- solve*
   "Runs the z3 solver with the constraints specified in `ctx`. Returns
   a witness if one exists, and `nil` if the constraints are unsat."
   [assertions]
@@ -26,12 +26,11 @@
      (when (str/starts-with? z3-output "sat")
        (if negative (- witness) witness)))))
 
-(defn witness*
+(def solve (memoize solve*))
+
+(defn witness
   "Return a witness that satisfies a list of constraint sets."
   [constraint-sets]
   (let [assertions (map (fn [constraints] (map assert constraints)) constraint-sets)
         witness (map solve assertions)]
     witness))
-
-
-(def witness (memoize witness*))


### PR DESCRIPTION
This PR adds a transport layer that allows us to move strings with arbitrary sequences of bytes (like the null byte, `\u0000`), which may cause the strings to be semantically incorrect and consequently rejected by our underlying transport layer.

Additionally, the format of the table and path conditions have been significantly simplified. 