### PR TITLE
Create SFA from a table (new encoding)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,8 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.0"]
+                 [org.clojure/core.specs.alpha "0.2.44"]
+                 [org.clojure/test.check "0.9.0"]
                  [com.taoensso/carmine "2.19.1"]
                  [com.taoensso/tufte "2.0.1"]
                  [com.rpl/specter "1.1.2"]]

--- a/resources/Regex.xml
+++ b/resources/Regex.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="ISO-8859-1" ?>
-<!DOCTYPE configuration PUBLIC "-//DEEPSEA//COASTAL configuration//EN"
-        "https://deepseaplatform.github.io/coastal/coastal.dtd">
+<!-- <?xml version="1.0" encoding="ISO-8859-1" ?> -->
+<!-- <!DOCTYPE configuration PUBLIC "-//DEEPSEA//COASTAL configuration//EN" -->
+<!-- "https://deepseaplatform.github.io/coastal/coastal.dtd"> -->
 <configuration>
     <coastal>
         <target>

--- a/src/symlearn/coastal.clj
+++ b/src/symlearn/coastal.clj
@@ -1,5 +1,8 @@
 (ns symlearn.coastal
   (:require [clojure.string :as str]
+            [clojure.pprint :refer [pprint]]
+            [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]
             [taoensso.carmine :as car]
             [taoensso.tufte :as tufte]
             [clojure.walk :as walk]
@@ -178,9 +181,10 @@
 (defn make-table
   "Table"
   []
-  {:S {(query "") []}
-   :R {}
-   :E [""]})
+  (let [epsilon (query "")]
+    {:S {epsilon [(accepted? epsilon)]}
+     :R {}
+     :E [""]}))
 
 (defn fill-row
   [[path row] evidence]
@@ -270,6 +274,24 @@
     (fn [input]
       (let [results (map #(% input) assertions)]
         (not (some false? results))))))
+
+
+(install-parser! "(abc|a*)")
+
+(-> (make-table)
+    (add-path-condition (query "b"))
+    ;; (closed?) ; false
+    (close)
+    ;; (closed?) ; true
+    (add-path-condition (query "abc"))
+    (add-path-condition (query "abcd"))
+    (add-evidence "c")
+    (fill)
+    ;; (closed?) ; false
+    (close)
+    ;; (closed?) ; true
+    (pprint)
+    )
 
 (comment
 

--- a/src/symlearn/coastal.clj
+++ b/src/symlearn/coastal.clj
@@ -224,17 +224,21 @@
                                     table-with-ce
                                     prefixes)
         filled-table (fill table-with-prefixes)]
-    (if-not (closed? filled-table)
+    filled-table
+    #_(if-not (closed? filled-table)
       (close filled-table)
       filled-table)))
 
 (defn add-evidence
   "Table -> Evidence -> Table"
   [table evidence]
-  (-> table
-      (update :E #(conj % evidence))
-      fill
-      close))
+  (let [new-table (-> table
+                      (update :E #(conj % evidence))
+                      fill)]
+    (loop [table new-table]
+      (if (closed? table)
+        table
+        (recur (close table))))))
 
 ;; closing a table
 
@@ -421,7 +425,6 @@
                           :to (get state-map to)
                           :guard (intervals/constraint-set->CharPred guard)})
                        transitions)
-        _ (pprint relabeled)
         transitions (map transition->SFAInputMove relabeled)
         initial-state (get state-map (initial-state table))
         final-states (final-states table)]
@@ -430,8 +433,8 @@
      (int initial-state)
      (doto (LinkedList.) (.addAll (map int final-states)))
      intervals/solver
-     false
-     false)))
+     true
+     true)))
 
 
 (defn show-dot
@@ -460,3 +463,21 @@
       (show-dot :complete)
       println
       ))
+
+(defn a*|abc
+  []
+  (install-parser! "a*|abc")
+  (-> (make-table)
+
+      (add-path-condition (query "a"))
+      (add-evidence "a")
+
+      (add-path-condition (query "abc"))
+      (add-evidence "abc")
+
+      (add-path-condition (query "aa"))
+      (add-evidence "aa")
+
+      (show-dot :complete)))
+
+(a*|abc)

--- a/src/symlearn/coastal.clj
+++ b/src/symlearn/coastal.clj
@@ -247,31 +247,22 @@
           (update-in [:S] #(assoc % promotee row))))
     table))
 
-;; (prefixes (map->PathCondition (query "0-")))
+;; make an sfa from a table
 
-;; (-> (make-table)
-;;     (fill)
-;;     (add-path-condition (query "a"))
-;;     (add-path-condition (query "0-0-0"))
-;;     (add-evidence "b")
-;;     (fill)
-;;     (close)
-;;     (close)
-;;     ;; (fill)
-;;     ;; (closed?)
-;;     ;; (open-entries)
-;;     ;;  (close)
-;;     ;; (close)
-;;     ;; (keys)
-;;     (clojure.pprint/pprint)
-;;     ;; (fill)
-;;     ;; (fill)
-;;     ;; (:R)
-;;     ;; section->map
-;;     ;; (closed?)
-;;     ;; (open-entries)
-;;     #_(as-> $ (map (comp length :path) $)))
-
+(defn constraint-set->fn
+  [constraint-set]
+  (let [->fn (fn [[op bound]]
+               (case op
+                 ">=" #(>= % bound)
+                 ">" #(> % bound)
+                 "==" #(== % bound)
+                 "!=" #(not= % bound)
+                 "<" #(< % bound)
+                 "<=" #(<= % bound)))
+        fns (map ->fn constraint-set)]
+    (fn [input]
+      (let [tests (map #(% input) fns)]
+        (not (some false? tests))))))
 
 (comment
 
@@ -317,5 +308,4 @@
   ;; Stop Coastal
   (stop!)
 
-)
-
+  )

--- a/src/symlearn/coastal.clj
+++ b/src/symlearn/coastal.clj
@@ -251,18 +251,18 @@
 
 (defn constraint-set->fn
   [constraint-set]
-  (let [->fn (fn [[op bound]]
-               (case op
-                 ">=" #(>= % bound)
-                 ">" #(> % bound)
-                 "==" #(== % bound)
-                 "!=" #(not= % bound)
-                 "<" #(< % bound)
-                 "<=" #(<= % bound)))
-        fns (map ->fn constraint-set)]
+  (let [assert->fn (fn [[op bound]]
+                     (case op
+                       ">=" #(>= % bound)
+                       ">" #(> % bound)
+                       "==" #(== % bound)
+                       "!=" #(not= % bound)
+                       "<" #(< % bound)
+                       "<=" #(<= % bound)))
+        assertions (map assert->fn constraint-set)]
     (fn [input]
-      (let [tests (map #(% input) fns)]
-        (not (some false? tests))))))
+      (let [results (map #(% input) assertions)]
+        (not (some false? results))))))
 
 (comment
 

--- a/src/symlearn/coastal.clj
+++ b/src/symlearn/coastal.clj
@@ -338,6 +338,52 @@
 
 (comment "Evaluate a guard-fn" ((:guard-fn (first transitions)) (int 97)))
 
+(defn run-input
+  [table input]
+  (let [transitions (compute-transitions table)]
+    (reduce (fn [state ch]
+              (println (str "state " state ", looking at: " ch) )
+              (let [transitions-from-state (filter (fn [{:keys [from to guard-fn]}]
+                                                     (and
+                                                      (= state from)
+                                                      (guard-fn (int ch))))
+                                                   transitions)
+                    n-transitions (count transitions-from-state)]
+                (println transitions-from-state)
+                (cond
+                  (= 0 n-transitions) state ;; self loop
+                  (= 1 n-transitions) (:to (first transitions-from-state)) ;; jump as per transitions
+                  (>= 2 n-transitions) (let [targets (map :to transitions-from-state)
+                                            unique-targets (set targets)]
+                                        (if (= 1 (count unique-targets)) ;; jump to the one state possible
+                                          (first unique-targets)
+                                          [::non-determinism transitions-from-state]))
+                  :default state)))
+            (initial-state table)
+            input)))
+
+(comment
+  "Huh, this works pretty well"
+  (let [{:keys [S R E] :as table}
+       (-> (make-table)
+           (add-path-condition (query "b"))
+           (close)
+           (add-path-condition (query "abc"))
+           (fill)
+           ;; (close)
+           (add-path-condition (query "abca"))
+           (add-evidence "a")
+           (close)
+           (add-evidence "c")
+           (close))
+       states (states table)
+       _ (println (count S) (count R) (count (merge S R)))
+       s+r (merge S R)]
+   (println "----")
+   (pprint table)
+   (pprint (compute-transitions table))
+   (pprint (run-input table "abc"))))
+
 ;; domain demo
 (comment
   "Create a table, and compute the prefix pairs"
@@ -358,5 +404,5 @@
         s+r (merge S R)]
     (println "----")
     (println (initial-state table))
-    (pprint (compute-transitions table)))
+    (run-input table "hello"))
   )

--- a/src/symlearn/coastal.clj
+++ b/src/symlearn/coastal.clj
@@ -278,20 +278,34 @@
 
 (install-parser! "(abc|a*)")
 
-(-> (make-table)
-    (add-path-condition (query "b"))
-    ;; (closed?) ; false
-    (close)
-    ;; (closed?) ; true
-    (add-path-condition (query "abc"))
-    (add-path-condition (query "abcd"))
-    (add-evidence "c")
-    (fill)
-    ;; (closed?) ; false
-    (close)
-    ;; (closed?) ; true
-    (pprint)
-    )
+(defn root-entries
+  [{:keys [S R]}]
+  (group-by (comp first :constraints first) (merge S R)))
+
+(let [{:keys [S R] :as table}
+      (-> (make-table)
+          (add-path-condition (query "b"))
+          ;; (closed?) ; false
+          (close)
+          ;; (closed?) ; true
+          (add-path-condition (query "abc"))
+          (add-path-condition (query "abcd"))
+          (add-evidence "c")
+          (fill)
+          ;; (closed?) ; false
+          (close)
+          ;; (closed?) ; true
+          )]
+  (println "----")
+  (pprint S)
+  (pprint R)
+  (println "----")
+  (pprint (get  (root-entries table)  #{[">" 96] ["==" 97] [">=" 0] ["<" 98]} ))
+  (println "----"))
+
+
+(merge {:a :b} {:a :c})
+
 
 (comment
 

--- a/src/symlearn/intervals.clj
+++ b/src/symlearn/intervals.clj
@@ -22,7 +22,8 @@
   (intersection [this pred] "Return the intersection of `this` and `pred`.")
   (negate [this] "Return the negation of this `this`.")
   (equivalent? [this that] "Return true if `this` and `that` are equivalent.")
-  (generate-witness [this] "Return a character that satisfies the constraint in `this`."))
+  (generate-witness [this] "Return a character that satisfies the constraint in `this`.")
+  (satisfied-by [this character] "True if `character` satifies the constraints in `this`."))
 
 (defprotocol IInterval
   "A protocol for character predicates expressed as intervals."
@@ -48,6 +49,7 @@
   (negate [this] (.MkNot solver this))
   (equivalent? [this that] (.AreEquivalent solver this that))
   (generate-witness [this] (.generateWitness solver this))
+  (satisfied-by [this character] (.isSatisfiedBy this character))
 
   IInterval
   (left [this] (first (first (intervals this))))
@@ -79,6 +81,23 @@
   (from [this] "Return the state from which `this` transition originates.")
   (to [this] "Return the state to which `this` transition goes.")
   (guard [this] "Return the guard used by `this` to check if a transition should occur."))
+
+(defn constraint->CharPred
+  [[op bound]]
+  (case op
+    ">" (CharPred. (char (inc bound)) \uFFFF)
+    ">=" (CharPred. (char bound) \uFFFF)
+    "<" (CharPred. \u0000 (char (dec bound)))
+    "<=" (CharPred. \u0000 (char bound))
+    "==" (CharPred. (char bound))
+    "!=" (negate (CharPred. (char bound)))))
+
+(defn constraint-set->CharPred
+  [constraints]
+  (reduce (fn [predicate constraint]
+            (intersection predicate (constraint->CharPred constraint)))
+          (CharPred. \u0000 \uFFFF)
+          constraints))
 
 (extend-type SFAInputMove
   ITransition
@@ -168,6 +187,7 @@
                   (.append ") {\n")
                   (.append "\t\t\t\t\tstate = ")
                   (.append (.to transition))
+
                   (.append ";\n")
                   (.append "\t\t\t\t\tcontinue;\n")
                   (.append "\t\t\t\t}\n"))))))

--- a/src/symlearn/intervals.clj
+++ b/src/symlearn/intervals.clj
@@ -214,35 +214,3 @@
         (.append "\n}\n")))
 
     (.toString java-src)))
-
-(comment
-
-  (map (comp right guard) (transitions-from (regex->sfa "a|b") 0))
-
-  (.getMovesFrom (regex->sfa "a|b") (int 0))
-
-  (right (guard (first (get-transitions-from (regex->sfa "a|b") 0))))
-
-
-
-  (regex->sfa "0-0(-0)?")
-
-  (spit "Regex.java" (sfa->java (regex->sfa "(ab|b)+") "regex" "Regex"))
-
-  (println (sfa->java (regex->sfa "a") "examples.tacas2017" "Regex"))
-
-
-  (println (sfa->java (regex->sfa "a|b") "regex" "regex"))
-
-    (let [our-sfa (regex->sfa "a|(b|c)?")]
-      (println (sfa->java our-sfa "examples.tacas2017" "Regex") ))
-
-  (intervals (union (make-interval \a \g) (make-interval \z \z)))
-  pred
-  (left (make-interval \a \g))
-
-  (intervals (negate (make-interval \a \g)))
-
-  )
-
-


### PR DESCRIPTION
This PR adds the ability to create an executable SFA from a table that is closed and consistent. This forms part of our migration to a fully featured UTF-16 learner.